### PR TITLE
IssueXML.php: skip DOCTYPE (fixes cobertura)

### DIFF
--- a/src/PHPCodeBrowser/IssueXML.php
+++ b/src/PHPCodeBrowser/IssueXML.php
@@ -155,6 +155,9 @@ class IssueXML extends DOMDocument
     public function addXMLFile(DOMDocument $domDocument): void
     {
         foreach ($domDocument->childNodes as $node) {
+			if ($node instanceof DOMDocumentType) {
+				continue;
+			}
             $this->documentElement->appendChild($this->importNode($node, true));
         }
     }

--- a/src/PHPCodeBrowser/IssueXML.php
+++ b/src/PHPCodeBrowser/IssueXML.php
@@ -155,9 +155,9 @@ class IssueXML extends DOMDocument
     public function addXMLFile(DOMDocument $domDocument): void
     {
         foreach ($domDocument->childNodes as $node) {
-			if ($node instanceof DOMDocumentType) {
-				continue;
-			}
+            if ($node instanceof DOMDocumentType) {
+                continue;
+            }
             $this->documentElement->appendChild($this->importNode($node, true));
         }
     }


### PR DESCRIPTION
After adding Cobertura XML report to PHPUnit my phpcb crashed with:
> `PHP Fatal error:  Uncaught TypeError: DOMNode::appendChild(): Argument #1 ($node) must be of type DOMNode, bool given in /var/lib/jenkins/.composer/vendor/mayflower/php-codebrowser/src/PHPCodeBrowser/IssueXML.php:158`

This patch skips '<!DOCTYPE coverage SYSTEM ...' (cobertura), which is a DOMNode that can't be imported, and uses the following element instead.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
<coverage line-rate="0.71621621621622" branch-rate="0" lines-covered="371" lines-valid="518" branches-covered="0" branches-valid="0" complexity="264" version="0.4" timestamp="1709828073">
```

Might want to check for false also but i think this patch is already deterministic.